### PR TITLE
chore: remove tidyversedashboard

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -120,11 +120,6 @@
         "url": "https://github.com/ThinkR-open/thinkrtemplate"
     },
     {
-        "package": "tidyversedashboard",
-        "url": "https://github.com/ThinkR-open/tidyversedashboard",
-        "branch": "more-options"
-    },
-    {
         "package": "togglr",
         "url": "https://github.com/ThinkR-open/togglr"
     },


### PR DESCRIPTION
thinkr-open/tidyversedashboard was a forked of a tidyverse repo. We don't use it anymore internally.